### PR TITLE
feat: add rule options generic type support

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ run({
 `onResult` field can be a function to do custom assertions with the entire result object.
 
 ```ts
-import { runClassic } from 'eslint-vitest-rule-tester'
+import { run } from 'eslint-vitest-rule-tester'
 import { expect } from 'vitest'
 
 run({

--- a/src/rule-tester.ts
+++ b/src/rule-tester.ts
@@ -15,7 +15,7 @@ import { isUsingTypeScriptParser, normalizeCaseError, normalizeTestCase } from '
 import { getAjvInstance, getRuleOptionsSchema } from './vendor/ajv'
 import { applyFixes } from './vendor/fixer'
 
-export function createRuleTester(options: RuleTesterInitOptions): RuleTester {
+export function createRuleTester<RuleOptions = any>(options: RuleTesterInitOptions): RuleTester<RuleOptions> {
   const languageOptions = deepMerge(
     options.languageOptions ?? {
       parser: options.parser,
@@ -48,7 +48,7 @@ export function createRuleTester(options: RuleTesterInitOptions): RuleTester {
     ...options.defaultFilenames,
   }
 
-  async function each(c: TestCase) {
+  async function each(c: TestCase<RuleOptions>) {
     const testcase = normalizeTestCase(c, languageOptions, defaultFilenames)
 
     const {
@@ -200,20 +200,20 @@ export function createRuleTester(options: RuleTesterInitOptions): RuleTester {
     }
   }
 
-  async function valid(arg: ValidTestCase | string) {
+  async function valid(arg: ValidTestCase<RuleOptions> | string) {
     const result = await each(arg)
     expect.soft(result.result.messages, 'no errors on valid cases').toEqual([])
     expect.soft(result.result.fixed, 'no need to fix for valid cases').toBeFalsy()
     return result
   }
 
-  async function invalid(arg: InvalidTestCase | string) {
+  async function invalid(arg: InvalidTestCase<RuleOptions> | string) {
     const result = await each(arg)
     expect.soft(result.result.messages, 'expect errors').not.toEqual([])
     return result
   }
 
-  async function run(cases: TestCasesOptions) {
+  async function run(cases: TestCasesOptions<RuleOptions>) {
     describe(options.name || 'rule-to-test', () => {
       if (cases.valid?.length) {
         describe('valid', () => {

--- a/src/run.ts
+++ b/src/run.ts
@@ -4,22 +4,21 @@ import { createRuleTester } from './rule-tester'
 /**
  * Shortcut to run test cases for a rule
  */
-
-export function run(options: TestCasesOptions & RuleTesterInitOptions) {
-  const tester = createRuleTester(options)
+export function run<RuleOptions = any>(options: TestCasesOptions<RuleOptions> & RuleTesterInitOptions) {
+  const tester = createRuleTester<RuleOptions>(options)
   return tester.run(options)
 }
+
 /**
  * Shortcut to run test cases for a rule in classic style
  */
-
-export function runClassic(
+export function runClassic<RuleOptions = any>(
   ruleName: string,
   rule: RuleModule,
-  cases: TestCasesOptions,
+  cases: TestCasesOptions<RuleOptions>,
   options?: RuleTesterInitOptions,
 ) {
-  const tester = createRuleTester({
+  const tester = createRuleTester<RuleOptions>({
     rule,
     name: ruleName,
     ...options,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,11 @@
 import type { Linter } from 'eslint'
 
 export type Awaitable<T> = Promise<T> | T
-export interface ValidTestCaseBase extends CompatConfigOptions, RuleTesterBehaviorOptions {
+export interface ValidTestCaseBase<RuleOptions = any> extends CompatConfigOptions, RuleTesterBehaviorOptions {
   name?: string
   description?: string
   code: string
-  options?: any
+  options?: RuleOptions
   filename?: string
   only?: boolean
   skip?: boolean
@@ -29,7 +29,7 @@ export interface TestCaseError extends Partial<Linter.LintMessage> {
   type?: string
 }
 
-export interface InvalidTestCaseBase extends ValidTestCaseBase {
+export interface InvalidTestCaseBase<RuleOptions = any> extends ValidTestCaseBase<RuleOptions> {
   /**
    * Expected errors.
    * If a number is provided, it asserts that the number of errors is equal to the number provided.
@@ -49,10 +49,10 @@ export interface NormalizedTestCase extends InvalidTestCaseBase {
   code: string
 }
 
-export type InvalidTestCase = InvalidTestCaseBase | string
-export type ValidTestCase = ValidTestCaseBase | string
+export type InvalidTestCase<RuleOptions = any> = InvalidTestCaseBase<RuleOptions> | string
+export type ValidTestCase<RuleOptions = any> = ValidTestCaseBase<RuleOptions> | string
 
-export type TestCase = ValidTestCase | InvalidTestCase
+export type TestCase<RuleOptions = any> = ValidTestCase<RuleOptions> | InvalidTestCase<RuleOptions>
 
 export interface TestExecutionResult extends Linter.FixReport {
   /**
@@ -73,23 +73,23 @@ export interface CompatConfigOptions {
 
 export type RuleModule = any // to allow any rule module
 
-export interface RuleTester {
+export interface RuleTester<RuleOptions = any> {
   /**
    * Run a single test case
    */
-  each: (arg: TestCase) => Promise<{ testcase: NormalizedTestCase, result: TestExecutionResult }>
+  each: (arg: TestCase<RuleOptions>) => Promise<{ testcase: NormalizedTestCase, result: TestExecutionResult }>
   /**
    * Run a single valid test case
    */
-  valid: (arg: ValidTestCase) => Promise<{ testcase: NormalizedTestCase, result: TestExecutionResult }>
+  valid: (arg: ValidTestCase<RuleOptions>) => Promise<{ testcase: NormalizedTestCase, result: TestExecutionResult }>
   /**
    * Run a single invalid test case
    */
-  invalid: (arg: InvalidTestCase) => Promise<{ testcase: NormalizedTestCase, result: TestExecutionResult }>
+  invalid: (arg: InvalidTestCase<RuleOptions>) => Promise<{ testcase: NormalizedTestCase, result: TestExecutionResult }>
   /**
    * ESLint's RuleTester style test runner, that runs multiple test cases
    */
-  run: (options: TestCasesOptions) => Promise<void>
+  run: (options: TestCasesOptions<RuleOptions>) => Promise<void>
 }
 
 export interface RuleTesterBehaviorOptions {
@@ -137,9 +137,9 @@ export interface RuleTesterInitOptions extends CompatConfigOptions, RuleTesterBe
   defaultFilenames?: Partial<DefaultFilenames>
 }
 
-export interface TestCasesOptions {
-  valid?: (ValidTestCase | string)[]
-  invalid?: (InvalidTestCase | string)[]
+export interface TestCasesOptions<RuleOptions = any> {
+  valid?: (ValidTestCase<RuleOptions> | string)[]
+  invalid?: (InvalidTestCase<RuleOptions> | string)[]
   /**
    * Callback to be called after each test case
    */


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR add rule options generic type support to API `run`, `runClassic` and `createRuleTester`.

### Linked Issues

None.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

None.
