### PR TITLE
feat: add error message id generic type support

### DIFF
--- a/src/rule-tester.ts
+++ b/src/rule-tester.ts
@@ -15,7 +15,7 @@ import { isUsingTypeScriptParser, normalizeCaseError, normalizeTestCase } from '
 import { getAjvInstance, getRuleOptionsSchema } from './vendor/ajv'
 import { applyFixes } from './vendor/fixer'
 
-export function createRuleTester<RuleOptions = any>(options: RuleTesterInitOptions): RuleTester<RuleOptions> {
+export function createRuleTester<RuleOptions = any, MessageId extends string = string>(options: RuleTesterInitOptions): RuleTester<RuleOptions, MessageId> {
   const languageOptions = deepMerge(
     options.languageOptions ?? {
       parser: options.parser,
@@ -48,7 +48,7 @@ export function createRuleTester<RuleOptions = any>(options: RuleTesterInitOptio
     ...options.defaultFilenames,
   }
 
-  async function each(c: TestCase<RuleOptions>) {
+  async function each(c: TestCase<RuleOptions, MessageId>) {
     const testcase = normalizeTestCase(c, languageOptions, defaultFilenames)
 
     const {
@@ -207,13 +207,13 @@ export function createRuleTester<RuleOptions = any>(options: RuleTesterInitOptio
     return result
   }
 
-  async function invalid(arg: InvalidTestCase<RuleOptions> | string) {
+  async function invalid(arg: InvalidTestCase<RuleOptions, MessageId> | string) {
     const result = await each(arg)
     expect.soft(result.result.messages, 'expect errors').not.toEqual([])
     return result
   }
 
-  async function run(cases: TestCasesOptions<RuleOptions>) {
+  async function run(cases: TestCasesOptions<RuleOptions, MessageId>) {
     describe(options.name || 'rule-to-test', () => {
       if (cases.valid?.length) {
         describe('valid', () => {

--- a/src/run.ts
+++ b/src/run.ts
@@ -4,21 +4,21 @@ import { createRuleTester } from './rule-tester'
 /**
  * Shortcut to run test cases for a rule
  */
-export function run<RuleOptions = any>(options: TestCasesOptions<RuleOptions> & RuleTesterInitOptions) {
-  const tester = createRuleTester<RuleOptions>(options)
+export function run<RuleOptions = any, MessageId extends string = string>(options: TestCasesOptions<RuleOptions, MessageId> & RuleTesterInitOptions) {
+  const tester = createRuleTester<RuleOptions, MessageId>(options)
   return tester.run(options)
 }
 
 /**
  * Shortcut to run test cases for a rule in classic style
  */
-export function runClassic<RuleOptions = any>(
+export function runClassic<RuleOptions = any, MessageId extends string = string>(
   ruleName: string,
   rule: RuleModule,
-  cases: TestCasesOptions<RuleOptions>,
+  cases: TestCasesOptions<RuleOptions, MessageId>,
   options?: RuleTesterInitOptions,
 ) {
-  const tester = createRuleTester<RuleOptions>({
+  const tester = createRuleTester<RuleOptions, MessageId>({
     rule,
     name: ruleName,
     ...options,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,16 +7,16 @@ import { interpolate } from './vendor/interpolate'
 
 export { unindent as $, unindent }
 
-export function normalizeTestCase(
-  c: TestCase,
+export function normalizeTestCase<RuleOptions = any, MessageId extends string = string>(
+  c: TestCase<RuleOptions, MessageId>,
   languageOptions: Linter.Config['languageOptions'],
   defaultFilenames: DefaultFilenames,
   type?: 'valid' | 'invalid',
-): NormalizedTestCase {
+): NormalizedTestCase<RuleOptions, MessageId> {
   const obj = typeof c === 'string'
     ? { code: c }
     : { ...c }
-  const normalized = obj as NormalizedTestCase
+  const normalized = obj as NormalizedTestCase<RuleOptions, MessageId>
   normalized.type ||= type || (('errors' in obj || 'output' in obj) ? 'invalid' : 'valid')
 
   const merged: Linter.Config['languageOptions'] = {
@@ -47,7 +47,7 @@ export function normalizeTestCase(
   return normalized
 }
 
-export function normalizeCaseError(error: TestCaseError | string, rule?: RuleModule): Partial<Linter.LintMessage> {
+export function normalizeCaseError<MessageId extends string = string>(error: TestCaseError<MessageId> | MessageId, rule?: RuleModule): Partial<Linter.LintMessage> {
   if (typeof error === 'string')
     return { messageId: error }
   const clone = { ...error }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
Add `messageId` generic type support to `run`, `runClassic`, `createRuleTester`
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
