### PR TITLE
feat: deprecate `type` in `TestCaseError`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@ export type TestCaseError<MessageId extends string = string> = Partial<Linter.Li
   data?: Record<string, any>
   /**
    * Alias to `nodeType`
+   * @deprecated `nodeType` is deprecated and will be removed in the next major version.
    */
   type?: string
   messageId?: MessageId


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

See https://eslint.org/blog/2025/10/whats-coming-in-eslint-10.0.0/#removal-of-type-property-in-errors-of-invalid-ruletester-cases
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

https://github.com/eslint/eslint/issues/19029

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
